### PR TITLE
Fixed logger crash

### DIFF
--- a/tools/plot_logger.py
+++ b/tools/plot_logger.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg') #https://stackoverflow.com/questions/49921721/runtimeerror-main-thread-is-not-in-main-loop-with-matplotlib-and-flask
 import matplotlib.pyplot as plt
 from collections import OrderedDict
 


### PR DESCRIPTION
I got a weird crash and fixed it. It is related to the matplotlib backend. Somebody had a similar problem and proposed the patch on stack overflow.

Have a nice day!

#https://stackoverflow.com/questions/49921721/runtimeerror-main-thread-is-not-in-main-loop-with-matplotlib-and-flask

sh configs/cifar_experiment_quick.sh 
Training:  66%|██████████████████████████████████████████████████████▊                            | 33/50 [15:05<07:42, 27.19s/it, epoch=32, loss_avg=-.728, accuracy=50.6]Exception ignored in: <function Image.__del__ at 0x7ff08d00d160>
Traceback (most recent call last):
  File "/home/raphael/anaconda3/envs/simsiam/lib/python3.8/tkinter/__init__.py", line 4014, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Exception ignored in: <function Image.__del__ at 0x7ff08d00d160>
Traceback (most recent call last):
  File "/home/raphael/anaconda3/envs/simsiam/lib/python3.8/tkinter/__init__.py", line 4014, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Exception ignored in: <function Image.__del__ at 0x7ff08d00d160>
Traceback (most recent call last):
  File "/home/raphael/anaconda3/envs/simsiam/lib/python3.8/tkinter/__init__.py", line 4014, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Exception ignored in: <function Image.__del__ at 0x7ff08d00d160>
Traceback (most recent call last):
  File "/home/raphael/anaconda3/envs/simsiam/lib/python3.8/tkinter/__init__.py", line 4014, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Exception ignored in: <function Image.__del__ at 0x7ff08d00d160>
Traceback (most recent call last):
  File "/home/raphael/anaconda3/envs/simsiam/lib/python3.8/tkinter/__init__.py", line 4014, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Exception ignored in: <function Image.__del__ at 0x7ff08d00d160>
Traceback (most recent call last):
  File "/home/raphael/anaconda3/envs/simsiam/lib/python3.8/tkinter/__init__.py", line 4014, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Tcl_AsyncDelete: async handler deleted by the wrong thread
Aborted (core dumped)


